### PR TITLE
Fix streamsubscription no longer receiving events upon serf agent restart

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -1,6 +1,6 @@
-wget -q https://dl.bintray.com/mitchellh/serf/0.6.0_linux_amd64.zip
+wget -q https://releases.hashicorp.com/serf/0.8.1/serf_0.8.1_linux_amd64.zip
 sudo apt-get -yq install unzip
-unzip 0.6.0_linux_amd64.zip
+unzip serf_0.8.1_linux_amd64.zip
 sudo mv serf /usr/local/bin/
 sudo cp serf-agent.conf /etc/init/
 sudo start serf-agent

--- a/src/main/java/no/tv2/serf/client/ListenerTask.java
+++ b/src/main/java/no/tv2/serf/client/ListenerTask.java
@@ -46,13 +46,18 @@ class ListenerTask implements Callable<Boolean> {
             }
         } catch (SerfCommunicationException ex) {
             if (closed) {
-                //Closing the socket will throw exception. This prevents a stacktrace when it is closed properly.
+                // Closing the serfEndPoint will cause an exception because we are still in waiting for
+                // the ReadNextMap call to return.  But if closed = true, it was intentional
                 logger.debug("Socket closed");
             } else {
+                // If close is false the socket got closed unexpectedly. Notify the handlers to stop
+                for (ResponseHandler handler : handlers.values()) {
+                    handler.stop();
+                }
                 throw new SerfCommunicationException(ex);
             }
         }
-        //Return true means returns without exceptions
+        //Return true means returns without exceptions, BUT nobody cares about it.
         return true;
     }
 

--- a/src/test/java/no/tv2/serf/client/SerfClientIT.java
+++ b/src/test/java/no/tv2/serf/client/SerfClientIT.java
@@ -12,60 +12,66 @@ package no.tv2.serf.client;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.*;
+
 import org.junit.After;
+
 import static org.junit.Assert.*;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *
  * @author Arne M. Størksen <arne.storksen@tv2.no>
  */
 public class SerfClientIT {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(SerfClientIT.class);
 
-    private static final String SERF1_RPC_IP = "localhost";
+    private static final String SERF1_RPC_IP = "10.2.2.1";
     private static final int SERF1_RPC_PORT = 7373;
 
-    private static final String SERF2_RPC_IP = "localhost";
+    private static final String SERF2_RPC_IP = "10.2.2.1";
     private static final int SERF2_RPC_PORT = 7374;
-    
+
     private static final String SERF1_IP = "10.2.2.10";
     private static final int SERF1_PORT = 7946;
     private static final String SERF2_IP = "10.2.2.11";
     private static final int SERF2_PORT = 7946;
-    
+
     private Client client1;
     private Client client2;
-    
+    private SerfEndpoint endpoint;
+
     @Before
     public void before() throws IOException, SerfCommunicationException {
         logger.info("before");
         client1 = createClient(SERF1_RPC_IP, SERF1_RPC_PORT);
         client2 = createClient(SERF2_RPC_IP, SERF2_RPC_PORT);
     }
-    
+
     @After
-    public void after() throws SerfCommunicationException  {
+    public void after() throws SerfCommunicationException {
         logger.info("after");
         client1.close();
         client2.close();
     }
-    
+
     public Client createClient(String ip, int port) throws SerfCommunicationException, IOException {
-        SerfEndpoint ep = new SocketEndpoint(ip, port);
-        Client client = new Client(ep);
+        endpoint = new SocketEndpoint(ip, port);
+        Client client = new Client(endpoint);
         client.handshake();
         return client;
     }
-    
-    
+
+
     @Test
     public void testMembers() throws SerfCommunicationException {
         logger.info("testMembers");
@@ -74,16 +80,19 @@ public class SerfClientIT {
         MembersResponse response = client1.members();
         assertEquals(2, response.getMembers().size());
     }
-    
+
     @Test
     public void testFilteredMembers() throws SerfCommunicationException {
         logger.info("testFilteredMembers");
         Map<String, String> expected = ImmutableMap.<String, String>builder().put("test-tag", "tag-value").build();
-        
+
         client1.tags(expected, ImmutableList.<String>of());
-        
+
         MembersResponse membersFiltered = client1.membersFiltered(expected, "", "");
         assertEquals(1, membersFiltered.getMembers().size());
+
+        // clean up
+        client1.tags(ImmutableMap.<String, String>of(), ImmutableList.<String>of("test-tag"));
     }
 
     @Test
@@ -92,7 +101,7 @@ public class SerfClientIT {
         JoinResponse response = client1.join(ImmutableList.<String>of(SERF2_IP + ":" + SERF2_PORT), false);
         assertEquals(1, response.getNum());
     }
-    
+
     @Test
     public void testSendAndReceiveEvent() throws SerfCommunicationException {
         logger.info("testSendAndReceiveEvent");
@@ -114,7 +123,7 @@ public class SerfClientIT {
         StreamSubscription subscription = client1.stream("member-update");
         client2.leave();
         Event event = subscription.take();
-        
+
         assertEquals(EventType.MemberUpdate, event.getEventType());
     }
 
@@ -124,16 +133,19 @@ public class SerfClientIT {
         JoinResponse response = client1.join(ImmutableList.<String>of(SERF2_IP + ":" + SERF2_PORT), false);
         client1.forceLeave("serf2");
     }
-    
+
     @Test
     public void testCreateTags() throws SerfCommunicationException {
         logger.info("testCreateTags");
         Map<String, String> expected = ImmutableMap.<String, String>of("test-tag", "tag-value");
-        
+
         client1.tags(expected, ImmutableList.<String>of());
-        
+
         MembersResponse membersFiltered = client1.membersFiltered(expected, "", "");
         assertTrue(Maps.difference(expected, membersFiltered.getMembers().get(0).getTags()).areEqual());
+
+        // clean up
+        client1.tags(ImmutableMap.<String, String>of(), ImmutableList.<String>of("test-tag"));
     }
 
     @Test
@@ -141,13 +153,13 @@ public class SerfClientIT {
         logger.info("testDeleteTags");
         Map<String, String> tags = ImmutableMap.<String, String>builder().put("test-tag", "tag-value").build();
         List<String> deletedTags = ImmutableList.<String>of("test-tag");
-        
+
         client1.tags(tags, ImmutableList.<String>of());
         MembersResponse membersFiltered1 = client1.membersFiltered(tags, "", "");
         assertTrue(Maps.difference(tags, membersFiltered1.getMembers().get(0).getTags()).areEqual());
-        
+
         client1.tags(ImmutableMap.<String, String>of(), deletedTags);
-        
+
         MembersResponse membersFiltered2 = client1.membersFiltered(tags, "", "");
         assertEquals(0, membersFiltered2.getMembers().size());
     }
@@ -156,37 +168,37 @@ public class SerfClientIT {
     public void testLog() throws SerfCommunicationException {
         logger.info("testLog");
         JoinResponse response = client1.join(ImmutableList.<String>of(SERF2_IP + ":" + SERF2_PORT), false);
-        
+
         MonitorSubscription subscription = client1.monitor(LogLevel.info);
         client2.event("test-monitor", "test-monitor-payload", true);
         Log log = subscription.take();
         assertTrue(log.toString().contains("INFO"));
     }
-    
+
     @Test
     public void testQueryResponse() throws SerfCommunicationException {
         logger.info("testQueryResponse");
 
         JoinResponse response = client1.join(ImmutableList.<String>of(SERF2_IP + ":" + SERF2_PORT), false);
         assertEquals(1, response.getNum());
-        
+
         StreamSubscription streamSubscription = client2.stream("query");
         QuerySubscription querySubscription = client1.query("test-query", "test-payload", ImmutableList.<String>of("serf2"), ImmutableMap.<String, String>of(), true, 0);
-        
+
         Event event = streamSubscription.take();
         assertEquals(EventType.Query, event.getEventType());
-        
+
         QueryEvent queryEvent = (QueryEvent) event;
         assertEquals("test-query", queryEvent.getName());
         assertEquals("test-payload", queryEvent.getPayload());
-        
+
         int id = queryEvent.getId();
         client2.respond(id, "test-response");
 
         QueryResponse response1 = querySubscription.take();
         assertEquals(QueryResponseType.ack, response1.getType());
         assertEquals("serf2", response1.getFrom());
-        
+
         QueryResponse response2 = querySubscription.take();
         assertEquals(QueryResponseType.response, response2.getType());
         assertEquals("serf2", response2.getFrom());
@@ -194,7 +206,7 @@ public class SerfClientIT {
 
         QueryResponse response3 = querySubscription.take();
         assertEquals(QueryResponseType.done, response3.getType());
-        
+
     }
 
     @Test
@@ -202,10 +214,15 @@ public class SerfClientIT {
         logger.info("testStats");
 
         Map<String, String> expected = ImmutableMap.<String, String>of("teststat", "valstat");
+
         client1.tags(expected, ImmutableList.<String>of());
         StatsResponse statsResponse = client1.stats();
         assertTrue(Integer.valueOf(statsResponse.getStats().getSerf().getMembers()) > 0);
         assertTrue(Maps.difference(expected, statsResponse.getStats().getTags()).areEqual());
+
+        // clean up
+        client1.tags(ImmutableMap.<String, String>of(), ImmutableList.<String>of("teststat"));
+
     }
     
 }


### PR DESCRIPTION
If the serf agent restarts the socket connection gets closed. This resulted in a silent failure of the listenerTask without any of the handlers being aware that the connection was gone. 

Now the handlers are stopped when this happens. 